### PR TITLE
Ogre 1.12 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build/
+/_build/

--- a/include/ogreExporter.h
+++ b/include/ogreExporter.h
@@ -112,6 +112,7 @@ namespace OgreMayaExporter
 		float _lastStop_cam;
 		float _firstStart_cam;
 		Ogre::Root *mr;
+		Ogre::DefaultHardwareBufferManager* bufferManager;
 	};
 
 
@@ -125,13 +126,13 @@ namespace OgreMayaExporter
 		:m_pMesh(0), m_pMaterialSet(0)
 	{
 		MGlobal::displayInfo("Translating scene to OGRE format");		
-		//mr = new Ogre::Root();
+		mr = new Ogre::Root("", "", "ogreMayaExporter.log");
+		bufferManager = new Ogre::DefaultHardwareBufferManager; // needed because we don't have a rendersystem
 	}
 
 	// Routine for creating the plug-in
 	inline void* OgreExporter::creator()
 	{
-		//Ogre::Root *r = new Ogre::Root();
 		return new OgreExporter();
 	}
 

--- a/include/ogreExporter.h
+++ b/include/ogreExporter.h
@@ -105,12 +105,12 @@ namespace OgreMayaExporter
 		MSelectionList m_selList;
 		MTime m_curTime;
 
-		std::map<float,float> _vA_map;
-		std::map<float,float> _cam_vA_map;
-		float _lastStop;
-		float _firstStart;
-		float _lastStop_cam;
-		float _firstStart_cam;
+		std::map<double, double> _vA_map;
+		std::map<double, double> _cam_vA_map;
+		double _lastStop;
+		double _firstStart;
+		double _lastStop_cam;
+		double _firstStart_cam;
 		Ogre::Root *mr;
 		Ogre::DefaultHardwareBufferManager* bufferManager;
 	};

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -153,9 +153,9 @@ namespace OgreMayaExporter
 				// Get layered texture node
 				MFnDependencyNode* pLayeredTexNode = NULL;
 				if (m_type == MT_SURFACE_SHADER)
-					pShader->findPlug("outColor").connectedTo(colorSrcPlugs,true,false);
+					pShader->findPlug("outColor", true, &stat).connectedTo(colorSrcPlugs,true,false);
 				else
-					pShader->findPlug("color").connectedTo(colorSrcPlugs,true,false);
+					pShader->findPlug("color", true, &stat).connectedTo(colorSrcPlugs,true,false);
 				for (int i=0; i<colorSrcPlugs.length(); i++)
 				{
 					if (colorSrcPlugs[i].node().hasFn(MFn::kLayeredTexture))
@@ -166,10 +166,16 @@ namespace OgreMayaExporter
 				}
 
 				// Get inputs to layered texture
-				MPlug inputsPlug = pLayeredTexNode->findPlug("inputs");
+				int numInputs = 0;
+				MPlug inputsPlug;
+				if (pLayeredTexNode)
+				{
+					inputsPlug = pLayeredTexNode->findPlug("inputs", true);
+					numInputs = inputsPlug.numElements();
+				}
 
 				// Scan inputs and export textures
-				for (int i=inputsPlug.numElements()-1; i>=0; i--)
+				for (int i= numInputs - 1; i>=0; i--)
 				{
 					MFnDependencyNode* pTextureNode = NULL;
 					// Search for a connected texture
@@ -228,9 +234,9 @@ namespace OgreMayaExporter
 				// Get texture node
 				MFnDependencyNode* pTextureNode = NULL;
 				if (m_type == MT_SURFACE_SHADER)
-					pShader->findPlug("outColor").connectedTo(colorSrcPlugs,true,false);
+					pShader->findPlug("outColor", true).connectedTo(colorSrcPlugs,true,false);
 				else
-					pShader->findPlug("color").connectedTo(colorSrcPlugs,true,false);
+					pShader->findPlug("color", true).connectedTo(colorSrcPlugs,true,false);
 				for (int i=0; i<colorSrcPlugs.length(); i++)
 				{
 					if (colorSrcPlugs[i].node().hasFn(MFn::kFileTexture))
@@ -264,7 +270,7 @@ namespace OgreMayaExporter
 		m_type = MT_SURFACE_SHADER;
 		MPlugArray colorSrcPlugs;
 		// Check if material is textured
-		pShader->findPlug("outColor").connectedTo(colorSrcPlugs,true,false);
+		pShader->findPlug("outColor", true).connectedTo(colorSrcPlugs,true,false);
 		for (int i=0; i<colorSrcPlugs.length(); i++)
 		{
 			if (colorSrcPlugs[i].node().hasFn(MFn::kFileTexture))
@@ -282,8 +288,8 @@ namespace OgreMayaExporter
 
 		// Check if material is transparent
 		float trasp;
-		pShader->findPlug("outTransparencyR").getValue(trasp);
-		if (pShader->findPlug("outTransparency").isConnected() || trasp>0.0f)
+		pShader->findPlug("outTransparencyR", true).getValue(trasp);
+		if (pShader->findPlug("outTransparency", true).isConnected() || trasp>0.0f)
 			m_isTransparent = true;
 
 		// Get material colours
@@ -291,12 +297,12 @@ namespace OgreMayaExporter
 			m_diffuse = MColor(1.0,1.0,1.0,1.0);
 		else
 		{
-			pShader->findPlug("outColorR").getValue(m_diffuse.r);
-			pShader->findPlug("outColorG").getValue(m_diffuse.g);
-			pShader->findPlug("outColorB").getValue(m_diffuse.b);
+			pShader->findPlug("outColorR", true).getValue(m_diffuse.r);
+			pShader->findPlug("outColorG", true).getValue(m_diffuse.g);
+			pShader->findPlug("outColorB", true).getValue(m_diffuse.b);
 			float trasp;
-			pShader->findPlug("outTransparencyR").getValue(trasp);
-			m_diffuse.a = 1.0 - trasp;
+			pShader->findPlug("outTransparencyR", true).getValue(trasp);
+			m_diffuse.a = 1.0f - trasp;
 		}
 		m_ambient = MColor(0,0,0,1);
 		m_emissive = MColor(0,0,0,1);
@@ -311,7 +317,7 @@ namespace OgreMayaExporter
 		m_type = MT_LAMBERT;
 		MFnLambertShader* pLambert = new MFnLambertShader(pShader->object());
 		// Check if material is textured
-		pLambert->findPlug("color").connectedTo(colorSrcPlugs,true,false);
+		pLambert->findPlug("color", true).connectedTo(colorSrcPlugs,true,false);
 		for (int i=0; i<colorSrcPlugs.length(); i++)
 		{
 			if (colorSrcPlugs[i].node().hasFn(MFn::kFileTexture))
@@ -328,7 +334,7 @@ namespace OgreMayaExporter
 		}
 
 		// Check if material is transparent
-		if (pLambert->findPlug("transparency").isConnected() || pLambert->transparency().r>0.0f)
+		if (pLambert->findPlug("transparency", true).isConnected() || pLambert->transparency().r>0.0f)
 			m_isTransparent = true;
 
 		// Get material colours
@@ -338,7 +344,7 @@ namespace OgreMayaExporter
 		else
 		{
 			m_diffuse = pLambert->color();
-			m_diffuse.a = 1.0 - pLambert->transparency().r;
+			m_diffuse.a = 1.0f - pLambert->transparency().r;
 		}
 		//ambient colour
 		m_ambient = pLambert->ambientColor();
@@ -357,7 +363,7 @@ namespace OgreMayaExporter
 		m_type = MT_PHONG;
 		MFnPhongShader* pPhong = new MFnPhongShader(pShader->object());
 		// Check if material is textured
-		pPhong->findPlug("color").connectedTo(colorSrcPlugs,true,false);
+		pPhong->findPlug("color", &stat).connectedTo(colorSrcPlugs,true,false);
 		for (int i=0; i<colorSrcPlugs.length(); i++)
 		{
 			if (colorSrcPlugs[i].node().hasFn(MFn::kFileTexture))
@@ -374,7 +380,7 @@ namespace OgreMayaExporter
 		}
 
 		// Check if material is transparent
-		if (pPhong->findPlug("transparency").isConnected() || pPhong->transparency().r>0.0f)
+		if (pPhong->findPlug("transparency", &stat).isConnected() || pPhong->transparency().r>0.0f)
 			m_isTransparent = true;
 
 		// Get material colours
@@ -384,7 +390,7 @@ namespace OgreMayaExporter
 		else
 		{
 			m_diffuse = pPhong->color();
-			m_diffuse.a = 1.0 - pPhong->transparency().r;
+			m_diffuse.a = 1.0f - pPhong->transparency().r;
 		}
 		//ambient colour
 		m_ambient = pPhong->ambientColor();
@@ -392,7 +398,7 @@ namespace OgreMayaExporter
 		m_emissive = pPhong->incandescence();
 		//specular colour
 		m_specular = pPhong->specularColor();
-		m_specular.a = pPhong->cosPower()*1.28;
+		m_specular.a = pPhong->cosPower()*1.28f;
 		delete pPhong;
 		return MS::kSuccess;
 	}
@@ -404,7 +410,7 @@ namespace OgreMayaExporter
 		m_type = MT_BLINN;
 		MFnBlinnShader* pBlinn = new MFnBlinnShader(pShader->object());
 		// Check if material is textured
-		pBlinn->findPlug("color").connectedTo(colorSrcPlugs,true,false);
+		pBlinn->findPlug("color", &stat).connectedTo(colorSrcPlugs,true,false);
 		for (int i=0; i<colorSrcPlugs.length(); i++)
 		{
 			if (colorSrcPlugs[i].node().hasFn(MFn::kFileTexture))
@@ -421,7 +427,7 @@ namespace OgreMayaExporter
 		}
 
 		// Check if material is transparent
-		if (pBlinn->findPlug("transparency").isConnected() || pBlinn->transparency().r>0.0f)
+		if (pBlinn->findPlug("transparency", &stat).isConnected() || pBlinn->transparency().r>0.0f)
 			m_isTransparent = true;
 
 		// Get material colours
@@ -431,7 +437,7 @@ namespace OgreMayaExporter
 		else
 		{
 			m_diffuse = pBlinn->color();
-			m_diffuse.a = 1.0 - pBlinn->transparency().r;
+			m_diffuse.a = 1.0f - pBlinn->transparency().r;
 		}
 		//ambient colour
 		m_ambient = pBlinn->ambientColor();
@@ -439,7 +445,7 @@ namespace OgreMayaExporter
 		m_emissive = pBlinn->incandescence();
 		//specular colour
 		m_specular = pBlinn->specularColor();
-		m_specular.a = 128.0-(128.0*pBlinn->eccentricity());
+		m_specular.a = 128.0f-(128.0f*pBlinn->eccentricity());
 		delete pBlinn;
 		return MS::kSuccess;
 	}
@@ -478,7 +484,7 @@ namespace OgreMayaExporter
 		tex.opType = opType;
 		// Get connections to uvCoord attribute of texture node
 		MPlugArray texSrcPlugs;
-		pTexNode->findPlug("uvCoord").connectedTo(texSrcPlugs,true,false);
+		pTexNode->findPlug("uvCoord", &stat).connectedTo(texSrcPlugs,true,false);
 		// Get place2dtexture node (if connected)
 		MFnDependencyNode* pPlace2dTexNode = NULL;
 		for (int j=0; j<texSrcPlugs.length(); j++)
@@ -494,7 +500,7 @@ namespace OgreMayaExporter
 		if (pPlace2dTexNode)
 		{
 			MPlugArray placetexSrcPlugs;
-			pPlace2dTexNode->findPlug("uvCoord").connectedTo(placetexSrcPlugs,true,false);
+			pPlace2dTexNode->findPlug("uvCoord", &stat).connectedTo(placetexSrcPlugs,true,false);
 			for (int j=0; j<placetexSrcPlugs.length(); j++)
 			{
 				if (placetexSrcPlugs[j].node().hasFn(MFn::kUvChooser))
@@ -509,7 +515,7 @@ namespace OgreMayaExporter
 		{
 			bool foundMesh = false;
 			bool foundUvset = false;
-			MPlug uvsetsPlug = pUvChooserNode->findPlug("uvSets");
+			MPlug uvsetsPlug = pUvChooserNode->findPlug("uvSets", &stat);
 			MPlugArray uvsetsSrcPlugs;
 			for (int i=0; i<uvsetsPlug.evaluateNumElements() && !foundMesh; i++)
 			{
@@ -537,8 +543,8 @@ namespace OgreMayaExporter
 			// Get address mode
 			//U
 			bool wrapU, mirrorU;
-			pPlace2dTexNode->findPlug("wrapU").getValue(wrapU);
-			pPlace2dTexNode->findPlug("mirrorU").getValue(mirrorU);
+			pPlace2dTexNode->findPlug("wrapU", &stat).getValue(wrapU);
+			pPlace2dTexNode->findPlug("mirrorU", &stat).getValue(mirrorU);
 			if (mirrorU)
 				tex.am_u = TAM_MIRROR;
 			else if (wrapU)
@@ -547,8 +553,8 @@ namespace OgreMayaExporter
 				tex.am_u = TAM_CLAMP;
 			// V
 			bool wrapV,mirrorV;
-			pPlace2dTexNode->findPlug("wrapV").getValue(wrapV);
-			pPlace2dTexNode->findPlug("mirrorV").getValue(mirrorV);
+			pPlace2dTexNode->findPlug("wrapV", &stat).getValue(wrapV);
+			pPlace2dTexNode->findPlug("mirrorV", &stat).getValue(mirrorV);
 			if (mirrorV)
 				tex.am_v = TAM_MIRROR;
 			else if (wrapV)
@@ -557,8 +563,8 @@ namespace OgreMayaExporter
 				tex.am_v = TAM_CLAMP;
 			// Get texture scale
 			double covU,covV;
-			pPlace2dTexNode->findPlug("coverageU").getValue(covU);
-			pPlace2dTexNode->findPlug("coverageV").getValue(covV);
+			pPlace2dTexNode->findPlug("coverageU", &stat).getValue(covU);
+			pPlace2dTexNode->findPlug("coverageV", &stat).getValue(covV);
 			tex.scale_u = covU;
 			if (fabs(tex.scale_u) < PRECISION)
 				tex.scale_u = 0;
@@ -567,8 +573,8 @@ namespace OgreMayaExporter
 				tex.scale_v = 0;
 			// Get texture scroll
 			double transU,transV;
-			pPlace2dTexNode->findPlug("translateFrameU").getValue(transU);
-			pPlace2dTexNode->findPlug("translateFrameV").getValue(transV);
+			pPlace2dTexNode->findPlug("translateFrameU", &stat).getValue(transU);
+			pPlace2dTexNode->findPlug("translateFrameV", &stat).getValue(transV);
 			tex.scroll_u = -0.5 * (covU-1.0)/covU - transU/covU;
 			if (fabs(tex.scroll_u) < PRECISION)
 				tex.scroll_u = 0;
@@ -577,7 +583,7 @@ namespace OgreMayaExporter
 				tex.scroll_v = 0;
 			// Get texture rotation
 			double rot;
-			pPlace2dTexNode->findPlug("rotateFrame").getValue(rot);
+			pPlace2dTexNode->findPlug("rotateFrame", &stat).getValue(rot);
 			tex.rot = -rot;
 			if (fabs(rot) < PRECISION)
 				tex.rot = 0;

--- a/src/ogreExporter.cpp
+++ b/src/ogreExporter.cpp
@@ -23,10 +23,10 @@
 - maintained by Bitgate, Inc. for the purpose of keeping Ogre compatible with the latest	-
 - technologies.																				-
 ---------------------------------------------------------------------------------------------
-- Copyright (c) 2011 MFG Baden-Württemberg, Innovation Agency for IT and media.             -
+- Copyright (c) 2011 MFG Baden-Wï¿½rttemberg, Innovation Agency for IT and media.             -
 - Research and Development at the Institute of Animation is a cooperation between           -
-- MFG Baden-Württemberg, Innovation Agency for IT and media and                             -
-- Filmakademie Baden-Württemberg as part of the "MFG Visual Experience Lab".                -
+- MFG Baden-Wï¿½rttemberg, Innovation Agency for IT and media and                             -
+- Filmakademie Baden-Wï¿½rttemberg as part of the "MFG Visual Experience Lab".                -
 ---------------------------------------------------------------------------------------------
 - This program is free software; you can redistribute it and/or modify it under				-
 - the terms of the GNU Lesser General Public License as published by the Free Software		-
@@ -1128,7 +1128,7 @@ namespace OgreMayaExporter
 MStatus initializePlugin( MObject obj )
 {
 	MStatus   status;
-	MFnPlugin plugin( obj, "OgreExporter", "v1.0.0-github", "Any");
+	MFnPlugin plugin( obj, "OgreExporter", "v2023.1", "Any");
 	status = plugin.registerCommand( "ogreExport", OgreMayaExporter::OgreExporter::creator );
 	if (!status) {
 		status.perror("registerCommand");

--- a/src/ogreExporter.cpp
+++ b/src/ogreExporter.cpp
@@ -371,8 +371,8 @@ namespace OgreMayaExporter
 		m_params.outAnim << "anim " << outString.asChar() << "\n";
 		m_params.outAnim <<"{\n";
 		m_params.outAnim << "\t//Time   /    Value\n";
-		float animStart = anim.time(0).as(MTime::kSeconds);
-		float animStop = anim.time(anim.numKeys()-1).as(MTime::kSeconds);
+		double animStart = anim.time(0).as(MTime::kSeconds);
+		double animStop = anim.time(anim.numKeys()-1).as(MTime::kSeconds);
 		
 		m_params.outAnimXML << "\t<animation name=\"" << outString.asChar() << "\" type=\"float\" start=\"" <<  animStart << "\" end=\"" << animStop << "\">\n" ;
 		for (uint i=0; i<anim.numKeys(); i++) {
@@ -394,14 +394,14 @@ namespace OgreMayaExporter
 			m_params.outAnim << "anim FOVy" << "\n";
 			m_params.outAnim <<"{\n";
 			m_params.outAnim << "\t//Time   /    Value\n";
-			std::map<float,float>::iterator av_it;
+			std::map<double, double>::iterator av_it;
 			if(anim.numKeys()>_vA_map.size()) {			
 						// TODO
 				}				
 			else {
 				for(av_it=_vA_map.begin();av_it!=_vA_map.end();av_it++) {			
-					float last_key = 0.0;
-					float take_this_key = -1.0;
+					double last_key = 0.0;
+					double take_this_key = -1.0;
 					for(uint i=0; i<anim.numKeys(); i++) {
 						if(abs(anim.time(i).as(MTime::kSeconds) - av_it->first)<0.0001) {
 							take_this_key = anim.value(i);
@@ -411,13 +411,13 @@ namespace OgreMayaExporter
 							last_key = anim.value(i);
 						}
 					}
-					float vA_val = av_it->second;
-					float focalLength = -1. ; 
+					double vA_val = av_it->second;
+					double focalLength = -1. ;
 					if(take_this_key > -1.1) 
 						focalLength = take_this_key;
 					else
 						focalLength = last_key;
-					float FOVy = 2*atan(vA_val*25.4/(2*focalLength)) * 180 / 3.141592654; 
+					double FOVy = 2*atan(vA_val*25.4/(2*focalLength)) * 180 / 3.141592654;
 					m_params.outAnim << "\t" << av_it->first << "\t" << FOVy << "\n";
 				}
 			}
@@ -444,8 +444,8 @@ namespace OgreMayaExporter
 		MFnAnimCurve* animCurve_z = NULL;
 		_firstStart_cam = 1e12;
 		_lastStop_cam = -1.;
-		float firstStart_cam_local = 1e12;
-		float lastStop_cam_local = -1.;
+		double firstStart_cam_local = 1e12;
+		double lastStop_cam_local = -1.;
 		std::stringbuf sbuf;
 		std::iostream outCamerasXML_tmp(&sbuf);
 		std::map<MTime, double* > keyMap;
@@ -493,8 +493,8 @@ namespace OgreMayaExporter
 					return MS::kFailure;
 				}
 			}
-			float animStart = animCurve_x->time(0).as(MTime::kSeconds);
-			float animStop = animCurve_x->time(animCurve_x->numKeys()-1).as(MTime::kSeconds);		
+			double animStart = animCurve_x->time(0).as(MTime::kSeconds);
+			double animStop = animCurve_x->time(animCurve_x->numKeys()-1).as(MTime::kSeconds);
 			if(animStart<_firstStart_cam)
 				_firstStart_cam = animStart;
 			if(animStop>_lastStop_cam)
@@ -544,8 +544,8 @@ namespace OgreMayaExporter
 					return MS::kFailure;
 				}
 			}
-			float animStart = animCurve_y->time(0).as(MTime::kSeconds);
-			float animStop = animCurve_y->time(animCurve_y->numKeys()-1).as(MTime::kSeconds);		
+			double animStart = animCurve_y->time(0).as(MTime::kSeconds);
+			double animStop = animCurve_y->time(animCurve_y->numKeys()-1).as(MTime::kSeconds);
 			if(animStart<_firstStart_cam)
 				_firstStart_cam = animStart;
 			if(animStop>_lastStop_cam)
@@ -610,8 +610,8 @@ namespace OgreMayaExporter
 					return MS::kFailure;
 				}
 			}
-			float animStart = animCurve_z->time(0).as(MTime::kSeconds);
-			float animStop = animCurve_z->time(animCurve_z->numKeys()-1).as(MTime::kSeconds);	
+			double animStart = animCurve_z->time(0).as(MTime::kSeconds);
+			double animStop = animCurve_z->time(animCurve_z->numKeys()-1).as(MTime::kSeconds);
 			if(animStart<_firstStart_cam)
 				_firstStart_cam = animStart;
 			if(animStop>_lastStop_cam)
@@ -694,8 +694,8 @@ namespace OgreMayaExporter
 					return MS::kFailure;
 				}
 			}
-			float animStart = animCurve_x->time(0).as(MTime::kSeconds);
-			float animStop = animCurve_x->time(animCurve_x->numKeys()-1).as(MTime::kSeconds);		
+			double animStart = animCurve_x->time(0).as(MTime::kSeconds);
+			double animStop = animCurve_x->time(animCurve_x->numKeys()-1).as(MTime::kSeconds);
 			if(animStart<_firstStart_cam)
 				_firstStart_cam = animStart;
 			if(animStop>_lastStop_cam)
@@ -744,8 +744,8 @@ namespace OgreMayaExporter
 					return MS::kFailure;
 				}
 			}
-			float animStart = animCurve_y->time(0).as(MTime::kSeconds);
-			float animStop = animCurve_y->time(animCurve_y->numKeys()-1).as(MTime::kSeconds);		
+			double animStart = animCurve_y->time(0).as(MTime::kSeconds);
+			double animStop = animCurve_y->time(animCurve_y->numKeys()-1).as(MTime::kSeconds);
 			if(animStart<_firstStart_cam)
 				_firstStart_cam = animStart;
 			if(animStop>_lastStop_cam)
@@ -810,8 +810,8 @@ namespace OgreMayaExporter
 					return MS::kFailure;
 				}
 			}
-			float animStart = animCurve_z->time(0).as(MTime::kSeconds);
-			float animStop = animCurve_z->time(animCurve_z->numKeys()-1).as(MTime::kSeconds);	
+			double animStart = animCurve_z->time(0).as(MTime::kSeconds);
+			double animStop = animCurve_z->time(animCurve_z->numKeys()-1).as(MTime::kSeconds);
 			if(animStart<_firstStart_cam)
 				_firstStart_cam = animStart;
 			if(animStop>_lastStop_cam)
@@ -890,8 +890,8 @@ namespace OgreMayaExporter
 					return MS::kFailure;
 				}
 			}
-			float animStart = animCurve->time(0).as(MTime::kSeconds);
-			float animStop = animCurve->time(animCurve->numKeys()-1).as(MTime::kSeconds);
+			double animStart = animCurve->time(0).as(MTime::kSeconds);
+			double animStop = animCurve->time(animCurve->numKeys()-1).as(MTime::kSeconds);
 			if(animStart<_firstStart_cam)
 				_firstStart_cam = animStart;
 			if(animStop>_lastStop_cam)
@@ -924,7 +924,7 @@ namespace OgreMayaExporter
 						return MS::kFailure;
 					}
 				}
-				std::map<float,float>::iterator av_it;
+				std::map<double, double>::iterator av_it;
 				m_params.outCameras << "anim FOVy\n";
 				m_params.outCameras <<"\t\t\t{\n";
 				m_params.outCameras << "\t\t\t//Time   /    Value\n";
@@ -934,8 +934,8 @@ namespace OgreMayaExporter
 					}				
 				else {
 					for(av_it=_vA_map.begin();av_it!=_vA_map.end();av_it++) {			
-						float last_key = 0.0;
-						float take_this_key = -1.0;
+						double last_key = 0.0;
+						double take_this_key = -1.0;
 						for(uint i=0; i<animCurve->numKeys(); i++) {
 							if(abs(animCurve->time(i).as(MTime::kSeconds) - av_it->first)<0.0001) {
 								take_this_key = animCurve->value(i);
@@ -945,13 +945,13 @@ namespace OgreMayaExporter
 								last_key = animCurve->value(i);
 							}
 						}
-						float vA_val = av_it->second;
-						float focalLength = -1. ; 
+						double vA_val = av_it->second;
+						double focalLength = -1. ;
 						if(take_this_key > -1.1) 
 							focalLength = take_this_key;
 						else
 							focalLength = last_key;
-						float FOVy = 2*atan(vA_val*25.4/(2*focalLength)) * 180 / 3.141592654; 
+						double FOVy = 2*atan(vA_val*25.4/(2*focalLength)) * 180 / 3.141592654;
 						outCamerasXML_tmp << "\t\t<keyframe time=\"" << av_it->first << "\" value=\"" << FOVy << "\"/>\n";
 					}				
 				}

--- a/src/ogreExporter.cpp
+++ b/src/ogreExporter.cpp
@@ -73,6 +73,10 @@ namespace OgreMayaExporter
 		m_pMesh = 0;
 		delete m_pMaterialSet;
 		m_pMaterialSet = 0;
+		delete mr;
+		mr = 0;
+		delete bufferManager;
+		bufferManager = 0;
 		// Close output files
 		m_params.closeFiles();
 		std::cout.flush();
@@ -994,17 +998,6 @@ namespace OgreMayaExporter
 	********************************************************************************************************/
 	MStatus OgreExporter::writeOgreData()
 	{
-		// Create singletons		
-		Ogre::LogManager logMgr;
-		Ogre::ResourceGroupManager rgm;
-		Ogre::MeshManager meshMgr;
-		Ogre::SkeletonManager skelMgr;
-		Ogre::MaterialManager matMgr;
-		Ogre::DefaultHardwareBufferManager hardwareBufMgr;
-		Ogre::LodStrategyManager lodMgr;
-		
-		// Create a log
-		logMgr.createLog("ogreMayaExporter.log", true);
 		// Write mesh binary
 		if (m_params.exportMesh)
 		{

--- a/src/skeleton.cpp
+++ b/src/skeleton.cpp
@@ -218,7 +218,7 @@ namespace OgreMayaExporter
 				localMatrix = bindMatrix;
 			}
 			// Get translation
-			MVector translation = ((MTransformationMatrix)localMatrix).translation(MSpace::kPostTransform);
+			MVector translation = ((MTransformationMatrix)localMatrix).getTranslation(MSpace::kPostTransform);
 			if (fabs(translation.x) < PRECISION)
 				translation.x = 0;
 			if (fabs(translation.y) < PRECISION)
@@ -259,7 +259,7 @@ namespace OgreMayaExporter
 				scale[2] = 0;
 			// Set joint info
 			newJoint.name = jointFn.partialPathName();
-			newJoint.id = m_joints.size();
+			newJoint.id = static_cast<long>(m_joints.size());
 			newJoint.parentIndex = idx;
 			newJoint.bindMatrix = bindMatrix;
 			newJoint.localMatrix = localMatrix;
@@ -270,9 +270,9 @@ namespace OgreMayaExporter
 			newJoint.axisx = axis.x;
 			newJoint.axisy = axis.y;
 			newJoint.axisz = axis.z;
-			newJoint.scalex = scale[0];
-			newJoint.scaley = scale[1];
-			newJoint.scalez = scale[2];
+			newJoint.scalex = static_cast<float>(scale[0]);
+			newJoint.scaley = static_cast<float>(scale[1]);
+			newJoint.scalez = static_cast<float>(scale[2]);
 			newJoint.jointDag = jointDag;
 			m_joints.push_back(newJoint);
 			// If root is a root joint, save its index in the roots list
@@ -460,8 +460,8 @@ namespace OgreMayaExporter
 		// test for non-uniform scale
 		testShear( j.name, relMatrix, "loadKeyframe result" );
 		// Get relative translation
-		MVector translation = ((MTransformationMatrix)localMatrix).translation(MSpace::kPostTransform) - 
-			((MTransformationMatrix)j.localMatrix).translation(MSpace::kPostTransform);
+		MVector translation = ((MTransformationMatrix)localMatrix).getTranslation(MSpace::kPostTransform) - 
+			((MTransformationMatrix)j.localMatrix).getTranslation(MSpace::kPostTransform);
 		if (fabs(translation.x) < PRECISION)
 			translation.x = 0;
 		if (fabs(translation.y) < PRECISION)
@@ -600,8 +600,8 @@ namespace OgreMayaExporter
 		pSkeleton->optimiseAllAnimations();
 		// Export skeleton binary
 		Ogre::SkeletonSerializer serializer;
-		serializer.exportSkeleton(pSkeleton.getPointer(),params.skeletonFilename.asChar());
-		pSkeleton.setNull();
+		serializer.exportSkeleton(pSkeleton.get(),params.skeletonFilename.asChar());
+		pSkeleton.reset();
 		// Skeleton successfully exported
 		return MS::kSuccess;
 	}

--- a/src/submesh.cpp
+++ b/src/submesh.cpp
@@ -385,6 +385,7 @@ namespace OgreMayaExporter
 	// Write submesh data to an Ogre compatible mesh
 	MStatus Submesh::createOgreSubmesh(Ogre::MeshPtr pMesh,const ParamList& params)
 	{
+		Ogre::MaterialManager* matMgr = Ogre::MaterialManager::getSingletonPtr();
 		MStatus stat;
 		// Create a new submesh
 		Ogre::SubMesh* pSubmesh;
@@ -392,8 +393,15 @@ namespace OgreMayaExporter
 			pSubmesh = pMesh->createSubMesh(m_name.asChar());
 		else
 			pSubmesh = pMesh->createSubMesh();
+        const Ogre::String materialName = m_pMaterial->name().asChar();
+        Ogre::MaterialPtr pMat = matMgr->getByName(materialName);
+        if (!pMat)
+        {
+            // Load a dummy material if necessary so it can be referenced in export.
+            pMat = matMgr->create(materialName, pMesh->getGroup());
+        }
 		// Set material
-        pSubmesh->setMaterialName(m_pMaterial->name().asChar());
+		pSubmesh->setMaterialName(materialName);
         // Set use shared geometry flag
 		pSubmesh->useSharedVertices = params.useSharedGeom;
 		// Create vertex data for current submesh

--- a/src/submesh.cpp
+++ b/src/submesh.cpp
@@ -114,7 +114,7 @@ namespace OgreMayaExporter
 		MFnDependencyNode* pShader;
 		//get shader from shading group
 		MFnDependencyNode shadingGroup(shader);
-		plug = shadingGroup.findPlug("surfaceShader");
+		plug = shadingGroup.findPlug("surfaceShader",true,&stat);
 		plug.connectedTo(srcplugarray,true,false,&stat);
 		for (int i=0; i<srcplugarray.length() && !foundShader; i++)
 		{
@@ -184,7 +184,7 @@ namespace OgreMayaExporter
 		std::cout << "Loading submesh : " << m_name.asChar() << "...";
 		std::cout.flush();
 		//save uvsets info
-		for (int i=m_uvsets.size(); i<texcoordsets.length(); i++)
+		for (size_t i=m_uvsets.size(); i<texcoordsets.length(); i++)
 		{
 			uvset uv;
 			uv.size = 2;
@@ -228,7 +228,7 @@ namespace OgreMayaExporter
 					if (vtx_mapping[idx] == -1)
 					{
 						m_indices.push_back(idx);
-						new_idx = m_indices.size() - 1;
+						new_idx = static_cast<long>(m_indices.size()) - 1;
 						vtx_mapping[idx] = new_idx;
 					}
 					else
@@ -545,15 +545,15 @@ namespace OgreMayaExporter
 				{
 				case Ogre::VES_POSITION:
 					elem.baseVertexPointerToElement(pBase, &pFloat);
-					*pFloat++ = v.x;
-					*pFloat++ = v.y;
-					*pFloat++ = v.z;
+					*pFloat++ = static_cast<float>(v.x);
+					*pFloat++ = static_cast<float>(v.y);
+                    *pFloat++ = static_cast<float>(v.z);
 					break;
 				case Ogre::VES_NORMAL:
 					elem.baseVertexPointerToElement(pBase, &pFloat);
-					*pFloat++ = v.n.x;
-					*pFloat++ = v.n.y;
-					*pFloat++ = v.n.z;
+					*pFloat++ = static_cast<float>(v.n.x);
+					*pFloat++ = static_cast<float>(v.n.y);
+					*pFloat++ = static_cast<float>(v.n.z);
 					break;
 				case Ogre::VES_DIFFUSE:
 					{

--- a/src/submesh.cpp
+++ b/src/submesh.cpp
@@ -23,10 +23,10 @@
 - maintained by Bitgate, Inc. for the purpose of keeping Ogre compatible with the latest	-
 - technologies.																				-
 ---------------------------------------------------------------------------------------------
-- Copyright (c) 2011 MFG Baden-Württemberg, Innovation Agency for IT and media.             -
+- Copyright (c) 2011 MFG Baden-Wï¿½rttemberg, Innovation Agency for IT and media.             -
 - Research and Development at the Institute of Animation is a cooperation between           -
-- MFG Baden-Württemberg, Innovation Agency for IT and media and                             -
-- Filmakademie Baden-Württemberg as part of the "MFG Visual Experience Lab".                -
+- MFG Baden-Wï¿½rttemberg, Innovation Agency for IT and media and                             -
+- Filmakademie Baden-Wï¿½rttemberg as part of the "MFG Visual Experience Lab".                -
 ---------------------------------------------------------------------------------------------
 - This program is free software; you can redistribute it and/or modify it under				-
 - the terms of the GNU Lesser General Public License as published by the Free Software		-
@@ -118,10 +118,14 @@ namespace OgreMayaExporter
 		plug.connectedTo(srcplugarray,true,false,&stat);
 		for (int i=0; i<srcplugarray.length() && !foundShader; i++)
 		{
-			if (srcplugarray[i].node().hasFn(MFn::kLambert) || srcplugarray[i].node().hasFn(MFn::kSurfaceShader) || 
-				srcplugarray[i].node().hasFn(MFn::kPluginHwShaderNode) )
+			MObject object = srcplugarray[i].node();
+			MFnDependencyNode node(object);
+			if (object.hasFn(MFn::kLambert) 
+			|| object.hasFn(MFn::kSurfaceShader) 
+			|| object.hasFn(MFn::kPluginHwShaderNode) 
+			|| node.typeName(&stat) == "aiStandardSurface")
 			{
-				pShader = new MFnDependencyNode(srcplugarray[i].node());
+				pShader = new MFnDependencyNode(object);
 				foundShader = true;
 			}
 		}


### PR DESCRIPTION
- Updated the plugin to initialize Ogre 1.12 using the OgreRoot.
- Fixed material assignment for submeshes.
- Added support for Arnold AiStandardSurface materials.
- Addressed Maya deprecation warnings.
- Addressed Ogre deprecation warnings.
- Addressed some (not all) type conversion warnings.